### PR TITLE
Elasticsearchのテスト実行時のindex作成処理をリファクタリング

### DIFF
--- a/spec/factories/manga.rb
+++ b/spec/factories/manga.rb
@@ -1,4 +1,3 @@
-
 FactoryBot.define do
   factory :manga do
     association :category, factory: :category

--- a/spec/models/concerns/manga_search/engine_spec.rb
+++ b/spec/models/concerns/manga_search/engine_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe MangaSearch::Engine, elasticsearch: true do
+RSpec.describe MangaSearch::Engine, elasticsearch: true, model_name: "manga" do
   describe 'Manga.search' do
     describe '検索ワードにマッチする漫画の検索' do
       let!(:manga_1) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,8 +63,10 @@ RSpec.configure do |config|
 
   # elasticsearchのテストの場合のみIndexを作成する
   config.before :each do |example|
-    if example.metadata[:elasticsearch]
-      Manga.create_index!
+    if example.metadata[:elasticsearch] && example.metadata[:model_name]
+      # meta情報のモデル名の文字列をクラス定数に変換し、Elasticsearchのindexを作成する
+      class_constant = example.metadata[:model_name].classify.constantize
+      class_constant.create_index!
     end
   end
 


### PR DESCRIPTION
## やったこと
- [x] RSpec実行時のElasticsearchのindex作成処理を複数のモデルで共通に使い回せるように修正。
